### PR TITLE
Unk frequency

### DIFF
--- a/sample_data/sample_config.ini
+++ b/sample_data/sample_config.ini
@@ -52,6 +52,7 @@ source_vocabulary_type=word
 target_vocabulary_type=word
 
 ; Vocabulary size in each side.
+unk_frequency=0
 source_vocabulary_size=4100
 target_vocabulary_size=4900
 

--- a/sample_data/tiny_config.ini
+++ b/sample_data/tiny_config.ini
@@ -17,7 +17,8 @@ test_target=sample_data/tiny.out
 [Model]
 source_vocabulary_type=word
 target_vocabulary_type=word
-source_vocabulary_size=30
+unk_frequency=0
+source_vocabulary_size=33
 target_vocabulary_size=33
 encoder_type=bidirectional
 decoder_type=default

--- a/src/bin/train.cc
+++ b/src/bin/train.cc
@@ -172,6 +172,7 @@ void initializeLogger(
 // Arguments:
 //   corpus_filepath: Location of the corpus file to be analyzed.
 //   vocab_type: Name of the vocabulary type.
+//   unk_frequency: Frequency of unknown word.
 //   vocab_size: Number of entries in the vocabulary.
 //
 // Returns:
@@ -183,11 +184,12 @@ void initializeLogger(
 nmtkit::Vocabulary * createVocabulary(
     const string & corpus_filepath,
     const string & vocab_type,
+    const unsigned unk_frequency,
     const unsigned vocab_size) {
   if (vocab_type == "character") {
-    return new nmtkit::CharacterVocabulary(corpus_filepath, vocab_size);
+    return new nmtkit::CharacterVocabulary(corpus_filepath, unk_frequency, vocab_size);
   } else if (vocab_type == "word") {
-    return new nmtkit::WordVocabulary(corpus_filepath, vocab_size);
+    return new nmtkit::WordVocabulary(corpus_filepath, unk_frequency, vocab_size);
   }
   NMTKIT_FATAL("Invalid vocabulary type: " + vocab_type);
 }
@@ -370,11 +372,13 @@ int main(int argc, char * argv[]) {
         ::createVocabulary(
             config.get<string>("Corpus.train_source"),
             config.get<string>("Model.source_vocabulary_type"),
+            config.get<unsigned>("Model.unk_frequency"),
             config.get<unsigned>("Model.source_vocabulary_size")));
     boost::scoped_ptr<nmtkit::Vocabulary> trg_vocab(
         ::createVocabulary(
             config.get<string>("Corpus.train_target"),
             config.get<string>("Model.target_vocabulary_type"),
+            config.get<unsigned>("Model.unk_frequency"),
             config.get<unsigned>("Model.target_vocabulary_size")));
     ::saveArchive(model_dir / "source.vocab", archive_format, src_vocab);
     ::saveArchive(model_dir / "target.vocab", archive_format, trg_vocab);

--- a/src/include/nmtkit/character_vocabulary.h
+++ b/src/include/nmtkit/character_vocabulary.h
@@ -32,7 +32,7 @@ public:
   // Arguments:
   //   corpus_filename: Location of the corpus file to be analyzed.
   //   size: Size of the vocabulary.
-  CharacterVocabulary(const std::string & corpus_filename, unsigned size);
+  CharacterVocabulary(const std::string & corpus_filename, unsigned unk_frequency, unsigned size);
 
   ~CharacterVocabulary() override {}
 

--- a/src/include/nmtkit/word_vocabulary.h
+++ b/src/include/nmtkit/word_vocabulary.h
@@ -31,8 +31,9 @@ public:
   //
   // Arguments:
   //   corpus_filename: Location of the corpus file to be analyzed.
+  //   unk_frequency: A parameter to which word will be treated as unk.
   //   size: Size of the vocabulary.
-  WordVocabulary(const std::string & corpus_filename, unsigned size);
+  WordVocabulary(const std::string & corpus_filename, unsigned unk_frequency, unsigned size);
 
   ~WordVocabulary() override {}
 

--- a/src/lib/character_vocabulary.cc
+++ b/src/lib/character_vocabulary.cc
@@ -50,8 +50,10 @@ namespace nmtkit {
 
 CharacterVocabulary::CharacterVocabulary(
     const string & corpus_filename,
+    unsigned unk_frequency,
     unsigned size) {
-  NMTKIT_CHECK(size >= 3, "Size should be equal or greater than 3.");
+  NMTKIT_CHECK(!(unk_frequency == 0 && size == 0), "Either size or unk_frequency must be specified.");
+  NMTKIT_CHECK(unk_frequency > 0 || size >= 3, "Size should be equal or greater than 3.");
   ifstream ifs(corpus_filename);
   NMTKIT_CHECK(
       ifs.is_open(),
@@ -88,7 +90,13 @@ CharacterVocabulary::CharacterVocabulary(
   freq_.emplace_back(num_letters);
   freq_.emplace_back(num_lines);
   freq_.emplace_back(num_lines);
-  for (unsigned i = 3; i < size && i - 3 < entries.size(); ++i) {
+
+  unsigned longest_size = size;
+  if (unk_frequency > 0) {
+    longest_size = entries.size();
+  }
+
+  for (unsigned i = 3; i < longest_size && i - 3 < entries.size() && entries[i-3].first > unk_frequency; ++i) {
     const auto & entry = entries[i - 3];
     stoi_[entry.second] = i;
     itos_.emplace_back(entry.second);


### PR DESCRIPTION
add option unk_frequency to adjust vocabulary size.
in a configuration file,

```
unk_frequency=0
```

to ignore this option.

by setting n to it, a word with the frequency under n will be treated as an unknown word.