### PR TITLE
Finish training if we cannot get better dev ppl. for N hours.

### DIFF
--- a/sample_data/sample_config.ini
+++ b/sample_data/sample_config.ini
@@ -180,6 +180,10 @@ dropout_ratio=0.3
 ; Maximum number of batch data to be trained.
 max_iteration=10000
 
+; Training will be stopped if we cannot get the lowest dev ppl. for this hours.
+; If this is set to 0, we don't stop training with this criteria.
+max_waiting_hour=24
+
 ; Timing of evaluating dev/test set. Available options:
 ; * step .... Number of steps (iterations).
 ; * sample .... Number of samples (sentences).

--- a/src/bin/train.cc
+++ b/src/bin/train.cc
@@ -536,29 +536,29 @@ int main(int argc, char * argv[]) {
         const float dev_log_ppl = ::evaluateLogPerplexity(
             encdec, dev_sampler, batch_converter);
         const auto fmt_dev_log_ppl = boost::format(
-            "Evaluated: batch=%d words=%d elapsed-time(sec)=%d dev-log-ppl=%.6e")
-            % iteration % num_trained_words % elapsed_time_seconds % dev_log_ppl;
+            "Evaluated: batch=%d samples=%d words=%d elapsed-time(sec)=%d dev-log-ppl=%.6e")
+            % iteration % num_trained_samples % num_trained_words % elapsed_time_seconds % dev_log_ppl;
         logger->info(fmt_dev_log_ppl.str());
 
         const float dev_bleu = ::evaluateBLEU(
             *trg_vocab, encdec, dev_sampler, train_max_length);
         const auto fmt_dev_bleu = boost::format(
-            "Evaluated: batch=%d words=%d elapsed-time(sec)=%d dev-bleu=%.6f")
-            % iteration % num_trained_words % elapsed_time_seconds % dev_bleu;
+            "Evaluated: batch=%d samples=%d words=%d elapsed-time(sec)=%d dev-bleu=%.6f")
+            % iteration % num_trained_samples % num_trained_words % elapsed_time_seconds % dev_bleu;
         logger->info(fmt_dev_bleu.str());
 
         const float test_log_ppl = ::evaluateLogPerplexity(
             encdec, test_sampler, batch_converter);
         const auto fmt_test_log_ppl = boost::format(
-            "Evaluated: batch=%d words=%d elapsed-time(sec)=%d test-log-ppl=%.6e")
-            % iteration % num_trained_words % elapsed_time_seconds % test_log_ppl;
+            "Evaluated: batch=%d samples=%d words=%d elapsed-time(sec)=%d test-log-ppl=%.6e")
+            % iteration % num_trained_samples % num_trained_words % elapsed_time_seconds % test_log_ppl;
         logger->info(fmt_test_log_ppl.str());
 
         const float test_bleu = ::evaluateBLEU(
             *trg_vocab, encdec, test_sampler, train_max_length);
         const auto fmt_test_bleu = boost::format(
-            "Evaluated: batch=%d words=%d elapsed-time(sec)=%d test-bleu=%.6f")
-            % iteration % num_trained_words % elapsed_time_seconds % test_bleu;
+            "Evaluated: batch=%d samples=%d words=%d elapsed-time(sec)=%d test-bleu=%.6f")
+            % iteration % num_trained_samples % num_trained_words % elapsed_time_seconds % test_bleu;
         logger->info(fmt_test_bleu.str());
 
         if (lr_decay_type == "eval") {


### PR DESCRIPTION
I added the function to finish training if we cannot get better dev ppl. for N hours.
In the default settings I set it to 24 hours, so if 24 hours have passed after getting the best dev ppl., 
training will be finished automatically.

If set it to 0, we do not stop with this criteria.