### PR TITLE
Remove dynetcuda

### DIFF
--- a/m4/ax_dynet.m4
+++ b/m4/ax_dynet.m4
@@ -23,7 +23,7 @@ if test "x$dynet_dir" != "x"; then
   if test "x$cuda_dir" != "x"; then
     # DyNet with CUDA.
     DYNET_CPPFLAGS="-I${dynet_dir}"
-    DYNET_LDFLAGS="-L${dynet_dir}/build/dynet/ -lgdynet -ldynetcuda"
+    DYNET_LDFLAGS="-L${dynet_dir}/build/dynet/ -lgdynet"
   else
     # DyNet with CPU.
     DYNET_CPPFLAGS="-I${dynet_dir}"


### PR DESCRIPTION
I build nmtkit with CUDA 8.0 in Ubuntu 16.04.
Getting the following error.
```
/bin/bash ../../libtool  --tag=CXX   --mode=link g++ -I../../src/include -I/usr/include -I/usr/local/include/eigen -I/usr/local/src/dynet -I/usr/local/cuda/include -I../../submodules/mteval/src/include -I../../submodules/spdlog/include -g -O2 -std=c++11 -Wall -Werror -O2   -o decode decode.o -lstdc++ ../../src/lib/libnmtkit.la -L/usr/lib/x86_64-linux-gnu -lboost_filesystem -lboost_program_options -lboost_serialization -lboost_system -L/usr/local/src/dynet/build/dynet/ -lgdynet -ldynetcuda -L/usr/local/cuda/lib64 -lcublas -lcudart ../../submodules/mteval/src/lib/libmteval.la
libtool: link: g++ -I../../src/include -I/usr/include -I/usr/local/include/eigen -I/usr/local/src/dynet -I/usr/local/cuda/include -I../../submodules/mteval/src/include -I../../submodules/spdlog/include -g -O2 -std=c++11 -Wall -Werror -O2 -o .libs/decode decode.o  -lstdc++ ../../src/lib/.libs/libnmtkit.so -L/usr/lib/x86_64-linux-gnu -lboost_filesystem -lboost_program_options -lboost_serialization -lboost_system -L/usr/local/src/dynet/build/dynet/ -lgdynet -ldynetcuda -L/usr/local/cuda/lib64 -lcublas -lcudart ../../submodules/mteval/src/lib/.libs/libmteval.so
/usr/bin/ld: cannot find -ldynetcuda
collect2: error: ld returned 1 exit status
make[3]: *** [decode] Error 1
```

Remove dynetcuda at https://github.com/clab/dynet/pull/311.